### PR TITLE
Replace wget with curl

### DIFF
--- a/biosig.rb
+++ b/biosig.rb
@@ -6,13 +6,12 @@ class Biosig < Formula
 
   # depends_on "cmake" => :build
   # depends_on :x11 # if your formula requires any X11/XQuartz components
-  depends_on "wget" => :build
   depends_on "gnu-tar" => :build
   depends_on "libbiosig" => :build
   #depends_on "octave" => :recommended
 
   def install
-    #system "wget http://sourceforge.net/p/biosig/code/ci/master/tree/biosig4c++/Makefile?format=raw -O Makefile "
+    #system "curl -L http://sourceforge.net/p/biosig/code/ci/master/tree/biosig4c++/Makefile?format=raw > Makefile"
 
     #ENV.deparallelize  # if your formula fails when building in parallel
 

--- a/biosig4mathematica.rb
+++ b/biosig4mathematica.rb
@@ -6,13 +6,12 @@ class Biosig4mathematica < Formula
 
   # depends_on "cmake" => :build
   # depends_on :x11 # if your formula requires any X11/XQuartz components
-  depends_on "wget" => :build
   depends_on "gnu-sed" => :build
   depends_on "libbiosig" => :build
   depends_on "ossp-uuid" => :build
 
   def install
-    #system "wget http://sourceforge.net/p/biosig/code/ci/master/tree/biosig4c++/Makefile?format=raw -O Makefile "
+    #system "curl -L http://sourceforge.net/p/biosig/code/ci/master/tree/biosig4c++/Makefile?format=raw > Makefile"
 
     #ENV.deparallelize  # if your formula fails when building in parallel
 

--- a/libbiosig.rb
+++ b/libbiosig.rb
@@ -7,7 +7,6 @@ class Libbiosig < Formula
 
   # depends_on "cmake" => :build
   # depends_on :x11 # if your formula requires any X11/XQuartz components
-  depends_on "wget" => :build
   depends_on "gawk" => :build
   depends_on "gnu-sed" => :build
   depends_on "gnu-tar" => :build
@@ -15,7 +14,7 @@ class Libbiosig < Formula
   #depends_on "octave" => :recommended
 
   def install
-    #system "wget http://sourceforge.net/p/biosig/code/ci/master/tree/biosig4c++/Makefile?format=raw -O Makefile "
+    #system "curl -L http://sourceforge.net/p/biosig/code/ci/master/tree/biosig4c++/Makefile?format=raw > Makefile"
 
     #ENV.deparallelize  # if your formula fails when building in parallel
 

--- a/mexbiosig.rb
+++ b/mexbiosig.rb
@@ -6,13 +6,12 @@ class Mexbiosig < Formula
 
   # depends_on "cmake" => :build
   # depends_on :x11 # if your formula requires any X11/XQuartz components
-  depends_on "wget" => :build
   depends_on "gnu-tar" => :build
   depends_on "libbiosig" => :build
   depends_on "homebrew/science/octave" => :build
 
   def install
-    #system "wget http://sourceforge.net/p/biosig/code/ci/master/tree/biosig4c++/Makefile?format=raw -O Makefile "
+    #system "curl -L http://sourceforge.net/p/biosig/code/ci/master/tree/biosig4c++/Makefile?format=raw > Makefile"
 
     #ENV.deparallelize  # if your formula fails when building in parallel
 

--- a/pyemf.rb
+++ b/pyemf.rb
@@ -6,7 +6,6 @@ class Pyemf < Formula
 
   # depends_on "cmake" => :build
   #depends_on :x11 # if your formula requires any X11/XQuartz components
-  depends_on "wget" => :build
   depends_on "gnu-tar" => :build
   depends_on "python"  => :build
 

--- a/sigviewer.rb
+++ b/sigviewer.rb
@@ -10,7 +10,6 @@ class Sigviewer < Formula
 
   # depends_on "cmake" => :build
   # depends_on :x11 # if your formula requires any X11/XQuartz components
-  depends_on "wget" => :build
   depends_on "libbiosig" => :build
   depends_on "qt" => :build
 

--- a/stimfit.rb
+++ b/stimfit.rb
@@ -10,7 +10,6 @@ class Stimfit < Formula
 
   # depends_on "cmake" => :build
   depends_on :x11 # if your formula requires any X11/XQuartz components
-  depends_on "wget" => :build
   depends_on "automake" => :build
   depends_on "autoconf" => :build
   depends_on "libbiosig" => :build
@@ -36,7 +35,7 @@ class Stimfit < Formula
 
     system "./configure --enable-python --with-biosig --with-pslope"
     
-    system "wget https://raw.githubusercontent.com/neurodroid/stimfit/master/Makefile.static -O Makefile.static"
+    system "curl -L https://raw.githubusercontent.com/neurodroid/stimfit/master/Makefile.static > Makefile.static"
 
     system "WXCONF=wx-config PREFIX=/usr/local make -f Makefile.static"
 


### PR DESCRIPTION
macOS comes with `curl` preinstalled, so there is no need to use `wget` as an extra dependency. I've replaced all `wget` occurrences with the corresponding `curl` commands.