### PR TITLE
Remove gnu-sed and gnu-tar deps

### DIFF
--- a/biosig.rb
+++ b/biosig.rb
@@ -4,11 +4,7 @@ class Biosig < Formula
   version "1.8.4"
   sha256 "bdb0ee11f4950f1e433148efa95b5ffedf91f62f3625e43c62b5b420bd3e0da5"
 
-  # depends_on "cmake" => :build
-  # depends_on :x11 # if your formula requires any X11/XQuartz components
-  depends_on "gnu-tar" => :build
   depends_on "libbiosig" => :build
-  #depends_on "octave" => :recommended
 
   def install
     #system "curl -L http://sourceforge.net/p/biosig/code/ci/master/tree/biosig4c++/Makefile?format=raw > Makefile"

--- a/biosig4mathematica.rb
+++ b/biosig4mathematica.rb
@@ -4,9 +4,6 @@ class Biosig4mathematica < Formula
   version "1.8.4"
   sha256 "bdb0ee11f4950f1e433148efa95b5ffedf91f62f3625e43c62b5b420bd3e0da5"
 
-  # depends_on "cmake" => :build
-  # depends_on :x11 # if your formula requires any X11/XQuartz components
-  depends_on "gnu-sed" => :build
   depends_on "libbiosig" => :build
   depends_on "ossp-uuid" => :build
 

--- a/libbiosig.rb
+++ b/libbiosig.rb
@@ -5,13 +5,8 @@ class Libbiosig < Formula
   version "1.8.4"
   sha256 "bdb0ee11f4950f1e433148efa95b5ffedf91f62f3625e43c62b5b420bd3e0da5"
 
-  # depends_on "cmake" => :build
-  # depends_on :x11 # if your formula requires any X11/XQuartz components
   depends_on "gawk" => :build
-  depends_on "gnu-sed" => :build
-  depends_on "gnu-tar" => :build
   depends_on "homebrew/science/suite-sparse" => :build
-  #depends_on "octave" => :recommended
 
   def install
     #system "curl -L http://sourceforge.net/p/biosig/code/ci/master/tree/biosig4c++/Makefile?format=raw > Makefile"

--- a/mexbiosig.rb
+++ b/mexbiosig.rb
@@ -4,9 +4,6 @@ class Mexbiosig < Formula
   version "1.8.4"
   sha256 "bdb0ee11f4950f1e433148efa95b5ffedf91f62f3625e43c62b5b420bd3e0da5"
 
-  # depends_on "cmake" => :build
-  # depends_on :x11 # if your formula requires any X11/XQuartz components
-  depends_on "gnu-tar" => :build
   depends_on "libbiosig" => :build
   depends_on "homebrew/science/octave" => :build
 

--- a/pyemf.rb
+++ b/pyemf.rb
@@ -4,9 +4,6 @@ class Pyemf < Formula
   version "2.0.0"
   sha256 "6960341434b9683926fba01f1fd81738234848c3f25883fa44c84b9833cf2354"
 
-  # depends_on "cmake" => :build
-  #depends_on :x11 # if your formula requires any X11/XQuartz components
-  depends_on "gnu-tar" => :build
   depends_on "python"  => :build
 
   def install

--- a/sigviewer.rb
+++ b/sigviewer.rb
@@ -8,8 +8,6 @@ class Sigviewer < Formula
   version "0.5.2"
   sha256 "2deb65c881fee46f921ab2299e5c0494113bd7c05a5d9ab328f3b7c839a94ba8"
 
-  # depends_on "cmake" => :build
-  # depends_on :x11 # if your formula requires any X11/XQuartz components
   depends_on "libbiosig" => :build
   depends_on "qt" => :build
 

--- a/stimfit.rb
+++ b/stimfit.rb
@@ -8,7 +8,6 @@ class Stimfit < Formula
   version "0.14.15windows"
   sha256 "6f767db350fd3d5321eda12781983b6e8f6170e0efac685bd3af81967428"
 
-  # depends_on "cmake" => :build
   depends_on :x11 # if your formula requires any X11/XQuartz components
   depends_on "automake" => :build
   depends_on "autoconf" => :build


### PR DESCRIPTION
Fixes #3. `tar` and `sed` is available on macOS, and the Homebrew packages `gnu-tar` and `gnu-sed` need to be called as `gtar` and `gsed`, respectively, so I doubt that these were used in the first place.